### PR TITLE
fix react version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add react-instascan react instascan-umd
 
 ## Requirements
 To use this library you need at least:
- - react >= 16
+ - react >= 16.3
  - instascan-umd >= 1
 
 # Using it

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "instascan-umd": ">= 1",
-    "react": ">= 16"
+    "react": ">= 16.3"
   },
   "dependencies": {
     "prop-types": "^15.6.1"


### PR DESCRIPTION
Hi There, just a small fix,  I've noticed that you're using `createRef`, which was introduced in 16.3. 

reference: 
https://github.com/facebook/react/blob/master/CHANGELOG.md#1630-march-29-2018